### PR TITLE
ci: Deploy production site to vercel

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,3 +38,4 @@ jobs:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ secrets.ORG_ID }}
           vercel-project-id: ${{ secrets.PROJECT_ID }}
+          vercel-args: ${{ github.ref == 'refs/heads/main' && '--prod' }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,4 +38,4 @@ jobs:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ secrets.ORG_ID }}
           vercel-project-id: ${{ secrets.PROJECT_ID }}
-          vercel-args: ${{ github.ref == 'refs/heads/main' && '--prod' }}
+          vercel-args: ${{ github.ref == 'refs/heads/main' && '--prod' || '' }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
       - name: build obsidian-zola
         env:
           REPO_URL: "https://github.com/junghoon-vans/vanstil/"
-          SITE_URL: "https://til-junghoon-vans.vercel.app/"
+          SITE_URL: ${{ github.ref == 'refs/heads/main' && 'https://til.vanslog.io/' || 'https://til-junghoon-vans.vercel.app/' }}
           SITE_TITLE: "vanstil"
           TIMEZONE: "Asia/Seoul"
           SORT_BY: "date"


### PR DESCRIPTION
메인 브랜치에 머지된 경우 프로덕션 사이트로 릴리즈하도록 하였습니다.
브랜치별로 사이트 url과 vercel 옵션을 구분하기 위해 아래와 같이 3항 연산자를 사용하였습니다.

### Site URL

```
SITE_URL: ${{ github.ref == 'refs/heads/main' && 'https://til.vanslog.io/' || 'https://til-junghoon-vans.vercel.app/' }}
```

### Vercel Args

```
vercel-args: ${{ github.ref == 'refs/heads/main' && '--prod' || '' }}
```
